### PR TITLE
feat: route-level and dynamic event metadata

### DIFF
--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'About',
+	description: 'The story behind Mumbo and the evolution of the sound',
+	path: '/about',
+	imagePath: '/images/mumbo-assets/M_B04850-1-NR.jpg',
+	imageAlt: 'About Mumbo',
+})
+
+export default function AboutLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Contact',
+	description: 'Bookings, collabs, and contact links for Mumbo',
+	path: '/contact',
+	imagePath: '/images/mumbo-assets/Mumbo_logo.png',
+	imageAlt: 'Contact Mumbo',
+})
+
+export default function ContactLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/events/[eventName]/layout.tsx
+++ b/src/app/events/[eventName]/layout.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next'
+import { findEventDetailBySlug } from '@/constants/event-details'
+import { createPageMetadata } from '@/lib/metadata'
+
+interface EventLayoutProps {
+	children: React.ReactNode
+	params: Promise<{
+		eventName: string
+	}>
+}
+
+export async function generateMetadata({
+	params,
+}: EventLayoutProps): Promise<Metadata> {
+	const { eventName } = await params
+	const event = findEventDetailBySlug(eventName)
+
+	if (!event) {
+		return {
+			title: 'Event Not Found | Mumbo',
+			description: 'This event could not be found. Browse all upcoming events.',
+			alternates: { canonical: '/events' },
+			openGraph: {
+				title: 'Event Not Found | Mumbo',
+				description:
+					'This event could not be found. Browse all upcoming events.',
+				url: 'https://mumbobeatz.com/events',
+				type: 'website',
+				images: [
+					{
+						url: '/images/mumbo-assets/2024_0906-Bloom_047.jpeg',
+						width: 1200,
+						height: 630,
+						alt: 'Mumbo events',
+					},
+				],
+			},
+			twitter: {
+				card: 'summary_large_image',
+				title: 'Event Not Found | Mumbo',
+				description:
+					'This event could not be found. Browse all upcoming events.',
+				images: ['/images/mumbo-assets/2024_0906-Bloom_047.jpeg'],
+			},
+		}
+	}
+
+	const description = `${event.date} • ${event.location} • ${event.description}`
+	const fullTitle = `${event.title} | Mumbo`
+
+	return createPageMetadata({
+		title: fullTitle,
+		description,
+		path: `/events/${event.eventName}`,
+		imagePath: event.imageUrl,
+		imageAlt: event.title,
+	})
+}
+
+export default function EventDetailLayout({ children }: EventLayoutProps) {
+	return children
+}

--- a/src/app/events/[eventName]/page.tsx
+++ b/src/app/events/[eventName]/page.tsx
@@ -1,178 +1,140 @@
-'use client';
+'use client'
 
-import { motion } from 'framer-motion';
-import Image from 'next/image';
-import { Button } from 'primereact/button';
-import { Card } from '@/components/ui/Card';
-import Link from 'next/link';
-import { use } from 'react';
-import { PAGE_SHELL_CLASS } from '@/constants/page-shell';
-
-interface Event {
-  id: string;
-  title: string;
-  date: string;
-  time: string;
-  location: string;
-  description: string;
-  imageUrl: string;
-  ticketUrl?: string;
-  eventName: string;
-}
-
-const events: Event[] = [
-  {
-    id: '1',
-    title: 'Mumbo Jumbo Ep. 6: Bloom Debut',
-    date: 'Sunday, April 14, 2024',
-    time: '22:00',
-    location: 'Bloom Nightclub, Downtown',
-    description: 'Experience the latest episode of Mumbo Jumbo live! Featuring new tracks and special guests.',
-    imageUrl: '/images/mumbo-assets/2024_0906-Bloom_047.jpeg',
-    ticketUrl: 'https://example.com/tickets',
-    eventName: 'mumbo-jumbo-ep-6-bloom-debut'
-  },
-  {
-    id: '2',
-    title: 'Project Seismic Launch Party',
-    date: 'Tuesday, April 30, 2024',
-    time: '21:00',
-    location: 'Underground Bass Club',
-    description: 'Join us for the official launch of Project Seismic with special guest performances.',
-    imageUrl: '/images/mumbo-assets/M_B04855-1-NR.jpg',
-    ticketUrl: 'https://example.com/project-seismic',
-    eventName: 'project-seismic-launch-party'
-  }
-];
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import { Button } from 'primereact/button'
+import { Card } from '@/components/ui/Card'
+import Link from 'next/link'
+import { use } from 'react'
+import { PAGE_SHELL_CLASS } from '@/constants/page-shell'
+import { findEventDetailBySlug } from '@/constants/event-details'
 
 interface EventPageProps {
-  params: Promise<{
-    eventName: string;
-  }>;
+	params: Promise<{
+		eventName: string
+	}>
 }
 
 export default function EventPage({ params }: EventPageProps) {
-  // Unwrap the params Promise using React.use()
-  const { eventName } = use(params);
-  
-  // Find the event based on the eventName parameter
-  const event = events.find(e => e.eventName === eventName);
+	const { eventName } = use(params)
+	const event = findEventDetailBySlug(eventName)
 
-  if (!event) {
-    return (
-      <div className={PAGE_SHELL_CLASS}>
-        <div className="text-center">
-          <h1 className="text-4xl font-bold mb-4">Event Not Found</h1>
-          <p className="text-color-secondary mb-8">
-            The event you&apos;re looking for doesn&apos;t exist.
-          </p>
-          <Link href="/events">
-            <Button label="Back to Events" icon="pi pi-arrow-left" className="p-button-rounded" />
-          </Link>
-        </div>
-      </div>
-    );
-  }
+	if (!event) {
+		return (
+			<div className={PAGE_SHELL_CLASS}>
+				<div className='text-center'>
+					<h1 className='mb-4 text-4xl font-bold'>Event Not Found</h1>
+					<p className='mb-8 text-color-secondary'>
+						The event you&apos;re looking for doesn&apos;t exist.
+					</p>
+					<Link href='/events'>
+						<Button
+							label='Back to Events'
+							icon='pi pi-arrow-left'
+							className='p-button-rounded'
+						/>
+					</Link>
+				</div>
+			</div>
+		)
+	}
 
-  return (
-    <div className={PAGE_SHELL_CLASS}>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
-        {/* Back Button */}
-        <div className="mb-8">
-          <Link href="/events">
-            <Button 
-              label="Back to Events" 
-              icon="pi pi-arrow-left" 
-              className="p-button-text p-button-rounded"
-            />
-          </Link>
-        </div>
+	return (
+		<div className={PAGE_SHELL_CLASS}>
+			<motion.div
+				initial={{ opacity: 0, y: 20 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.5 }}
+			>
+				<div className='mb-8'>
+					<Link href='/events'>
+						<Button
+							label='Back to Events'
+							icon='pi pi-arrow-left'
+							className='p-button-text p-button-rounded'
+						/>
+					</Link>
+				</div>
 
-        <Card className="overflow-hidden">
-          <div className="flex flex-col lg:flex-row gap-8">
-            {/* Large Image Section (Left) */}
-            <div className="w-full lg:w-2/3">
-              <div className="relative aspect-[4/3] lg:aspect-[3/2] rounded-lg overflow-hidden">
-                <Image
-                  src={event.imageUrl}
-                  alt={event.title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            </div>
+				<Card className='overflow-hidden'>
+					<div className='flex flex-col gap-8 lg:flex-row'>
+						<div className='w-full lg:w-2/3'>
+							<div className='relative aspect-[4/3] overflow-hidden rounded-lg lg:aspect-[3/2]'>
+								<Image
+									src={event.imageUrl}
+									alt={event.title}
+									fill
+									className='object-cover'
+								/>
+							</div>
+						</div>
 
-            {/* Event Details Section (Right) */}
-            <div className="w-full lg:w-1/3 flex flex-col justify-center space-y-6">
-              <div>
-                <h1 className="text-4xl font-bold mb-4">{event.title}</h1>
-                
-                <div className="space-y-3 text-color-secondary">
-                  <div className="flex items-center gap-3">
-                    <i className="pi pi-calendar text-primary-light"></i>
-                    <span>{event.date}</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <i className="pi pi-clock text-primary-light"></i>
-                    <span>{event.time}</span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <i className="pi pi-map-marker text-primary-light"></i>
-                    <span>{event.location}</span>
-                  </div>
-                </div>
-              </div>
+						<div className='flex w-full flex-col justify-center space-y-6 lg:w-1/3'>
+							<div>
+								<h1 className='mb-4 text-4xl font-bold'>{event.title}</h1>
 
-              <div className="space-y-4">
-                <p className="text-color-secondary leading-relaxed text-lg">
-                  {event.description}
-                </p>
-                
-                <div className="bg-background-paper/80 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold mb-2">Event Details</h3>
-                  <ul className="text-color-secondary space-y-2">
-                    <li>• Doors open 30 minutes before show time</li>
-                    <li>• 21+ event with valid ID required</li>
-                    <li>• No outside food or beverages</li>
-                    <li>• Photography allowed (no flash)</li>
-                  </ul>
-                </div>
-              </div>
+								<div className='space-y-3 text-color-secondary'>
+									<div className='flex items-center gap-3'>
+										<i className='pi pi-calendar text-primary-light'></i>
+										<span>{event.date}</span>
+									</div>
+									<div className='flex items-center gap-3'>
+										<i className='pi pi-clock text-primary-light'></i>
+										<span>{event.time}</span>
+									</div>
+									<div className='flex items-center gap-3'>
+										<i className='pi pi-map-marker text-primary-light'></i>
+										<span>{event.location}</span>
+									</div>
+								</div>
+							</div>
 
-              <div className="flex gap-4">
-                {event.ticketUrl && (
-                  <Button
-                    label="Get Tickets"
-                    icon="pi pi-ticket"
-                    onClick={() => window.open(event.ticketUrl, '_blank')}
-                    className="p-button-rounded"
-                  />
-                )}
-                <Button
-                  label="Share Event"
-                  icon="pi pi-share-alt"
-                  className="p-button-outlined p-button-rounded"
-                  onClick={() => {
-                    if (navigator.share) {
-                      navigator.share({
-                        title: event.title,
-                        text: event.description,
-                        url: window.location.href
-                      });
-                    } else {
-                      navigator.clipboard.writeText(window.location.href);
-                    }
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-        </Card>
-      </motion.div>
-    </div>
-  );
-} 
+							<div className='space-y-4'>
+								<p className='text-lg leading-relaxed text-color-secondary'>
+									{event.description}
+								</p>
+
+								<div className='rounded-lg bg-background-paper/80 p-4'>
+									<h3 className='mb-2 text-lg font-semibold'>Event Details</h3>
+									<ul className='space-y-2 text-color-secondary'>
+										<li>• Doors open 30 minutes before show time</li>
+										<li>• 21+ event with valid ID required</li>
+										<li>• No outside food or beverages</li>
+										<li>• Photography allowed (no flash)</li>
+									</ul>
+								</div>
+							</div>
+
+							<div className='flex gap-4'>
+								{event.ticketUrl && (
+									<Button
+										label='Get Tickets'
+										icon='pi pi-ticket'
+										onClick={() => window.open(event.ticketUrl, '_blank')}
+										className='p-button-rounded'
+									/>
+								)}
+								<Button
+									label='Share Event'
+									icon='pi pi-share-alt'
+									className='p-button-outlined p-button-rounded'
+									onClick={() => {
+										if (navigator.share) {
+											navigator.share({
+												title: event.title,
+												text: event.description,
+												url: window.location.href,
+											})
+										} else {
+											navigator.clipboard.writeText(window.location.href)
+										}
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+				</Card>
+			</motion.div>
+		</div>
+	)
+}

--- a/src/app/events/layout.tsx
+++ b/src/app/events/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Events',
+	description: 'Catch Mumbo live at upcoming shows and festivals',
+	path: '/events',
+	imagePath: '/images/mumbo-assets/2024_0906-Bloom_047.jpeg',
+	imageAlt: 'Mumbo live event',
+})
+
+export default function EventsLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/highlights/layout.tsx
+++ b/src/app/highlights/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Highlights',
+	description: 'Photos, reels, and standout moments from Mumbo shows',
+	path: '/highlights',
+	imagePath: '/images/mumbo-assets/M_B04850-1-NR.jpg',
+	imageAlt: 'Mumbo highlights',
+})
+
+export default function HighlightsLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,29 +4,29 @@ import 'primereact/resources/primereact.min.css'
 import 'primeicons/primeicons.css'
 import 'primeflex/primeflex.css'
 
+import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import ClientLayout from '@/components/layout/ClientLayout'
 import AuthProvider from '@/components/providers/AuthProvider'
+import { createPageMetadata } from '@/lib/metadata'
 
 const inter = Inter({ subsets: ['latin'] })
 
-export const metadata = {
+const homeMetadata = createPageMetadata({
 	title: 'Mumbo - Electronic Music Artist',
 	description: 'Experience the fusion of EDM and playful vibes',
+	path: '/',
+	imagePath: '/images/mumbo-assets/m_b06468.jpg',
+	imageAlt: 'Mumbo performing live',
+})
+
+export const metadata: Metadata = {
+	...homeMetadata,
+	title: {
+		default: 'Mumbo - Electronic Music Artist',
+		template: '%s | Mumbo',
+	},
 	metadataBase: new URL('https://mumbobeatz.com'),
-	openGraph: {
-		title: 'Mumbo - Electronic Music Artist',
-		description: 'Experience the fusion of EDM and playful vibes',
-		url: 'https://mumbobeatz.com',
-		siteName: 'Mumbo',
-		locale: 'en_US',
-		type: 'website',
-	},
-	twitter: {
-		card: 'summary_large_image',
-		title: 'Mumbo - Electronic Music Artist',
-		description: 'Experience the fusion of EDM and playful vibes',
-	},
 	robots: {
 		index: true,
 		follow: true,

--- a/src/app/merch/layout.tsx
+++ b/src/app/merch/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Merch',
+	description: 'Official Mumbo merchandise and upcoming drops',
+	path: '/merch',
+	imagePath: '/images/mumbo-assets/M_B04851-1-NR.jpg',
+	imageAlt: 'Mumbo merch',
+})
+
+export default function MerchLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/music/layout.tsx
+++ b/src/app/music/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Music',
+	description: 'Listen to Mumbo tracks, flips, and live sets',
+	path: '/music',
+	imagePath: '/images/mumbo-assets/IMG_6879.jpeg',
+	imageAlt: 'Mumbo music page',
+})
+
+export default function MusicLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/app/socials/layout.tsx
+++ b/src/app/socials/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+	title: 'Socials',
+	description: 'Find Mumbo on all social platforms and stay connected',
+	path: '/socials',
+	imagePath: '/images/mumbo-assets/Mumbo_logo.png',
+	imageAlt: 'Mumbo socials',
+})
+
+export default function SocialsLayout({
+	children,
+}: {
+	children: React.ReactNode
+}) {
+	return children
+}

--- a/src/constants/event-details.ts
+++ b/src/constants/event-details.ts
@@ -1,0 +1,42 @@
+export interface EventDetail {
+	id: string
+	title: string
+	date: string
+	time: string
+	location: string
+	description: string
+	imageUrl: string
+	ticketUrl?: string
+	eventName: string
+}
+
+export const EVENT_DETAILS: EventDetail[] = [
+	{
+		id: '1',
+		title: 'Mumbo Jumbo Ep. 6: Bloom Debut',
+		date: 'Sunday, April 14, 2024',
+		time: '22:00',
+		location: 'Bloom Nightclub, Downtown',
+		description:
+			'Experience the latest episode of Mumbo Jumbo live. Featuring new tracks and special guests.',
+		imageUrl: '/images/mumbo-assets/2024_0906-Bloom_047.jpeg',
+		ticketUrl: 'https://example.com/tickets',
+		eventName: 'mumbo-jumbo-ep-6-bloom-debut',
+	},
+	{
+		id: '2',
+		title: 'Project Seismic Launch Party',
+		date: 'Tuesday, April 30, 2024',
+		time: '21:00',
+		location: 'Underground Bass Club',
+		description:
+			'Join us for the official launch of Project Seismic with special guest performances.',
+		imageUrl: '/images/mumbo-assets/M_B04855-1-NR.jpg',
+		ticketUrl: 'https://example.com/project-seismic',
+		eventName: 'project-seismic-launch-party',
+	},
+]
+
+export function findEventDetailBySlug(eventName: string) {
+	return EVENT_DETAILS.find(event => event.eventName === eventName)
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+
+interface PageMetadataInput {
+	title: string
+	description: string
+	path: string
+	imagePath: string
+	imageAlt: string
+}
+
+export function createPageMetadata({
+	title,
+	description,
+	path,
+	imagePath,
+	imageAlt,
+}: PageMetadataInput): Metadata {
+	const url =
+		path === '/' ? 'https://mumbobeatz.com' : `https://mumbobeatz.com${path}`
+
+	return {
+		title,
+		description,
+		alternates: {
+			canonical: path,
+		},
+		openGraph: {
+			title,
+			description,
+			url,
+			siteName: 'Mumbo',
+			locale: 'en_US',
+			type: 'website',
+			images: [
+				{
+					url: imagePath,
+					width: 1200,
+					height: 630,
+					alt: imageAlt,
+				},
+			],
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title,
+			description,
+			images: [imagePath],
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable metadata builder for Open Graph/Twitter/canonical defaults
- add route-level metadata for home subpages (music, socials, events, highlights, about, contact, merch)
- add dynamic metadata for /events/[eventName] so each event slug has its own title, description, canonical URL, and image

## Test plan
- npm run build
- verify browser page titles on /music, /socials, /events
- verify dynamic title on /events/mumbo-jumbo-ep-6-bloom-debut

Made with [Cursor](https://cursor.com)