### PR TITLE
fix: center music cards on mobile

### DIFF
--- a/src/components/music/MusicReleaseCard.tsx
+++ b/src/components/music/MusicReleaseCard.tsx
@@ -56,7 +56,7 @@ export function MusicReleaseCard({ entry }: MusicReleaseCardProps) {
 			pt={{
 				root: {
 					className:
-						'h-full cursor-pointer border-round-xl overflow-hidden ' +
+						'h-full w-full cursor-pointer border-round-xl overflow-hidden ' +
 						'transition-shadow transition-duration-150 hover:shadow-md',
 				},
 				header: {

--- a/src/components/music/MusicReleaseGrid.tsx
+++ b/src/components/music/MusicReleaseGrid.tsx
@@ -5,9 +5,11 @@ import { MusicReleaseCard } from './MusicReleaseCard'
 
 export function MusicReleaseGrid({ items }: { items: MusicEntry[] }) {
 	return (
-		<div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
+		<div className='grid grid-cols-1 gap-6 justify-items-center md:grid-cols-2 md:justify-items-stretch lg:grid-cols-3'>
 			{items.map(entry => (
-				<MusicReleaseCard key={entry.title} entry={entry} />
+				<div key={entry.title} className='w-full max-w-sm md:max-w-none'>
+					<MusicReleaseCard entry={entry} />
+				</div>
 			))}
 		</div>
 	)


### PR DESCRIPTION
## Summary
- center single-column music release cards on mobile with consistent max width
- keep md+ behavior stretched per grid column
- ensure card root uses full width so Prime Card doesn’t collapse to intrinsic width

## Test plan
- npm run build
- browser check on /music at 390x844
- verify Songs cards are centered and evenly spaced

Made with [Cursor](https://cursor.com)