### PR TITLE
fix: center music card titles and link rows on mobile

### DIFF
--- a/src/components/music/MusicPlatformBubbles.tsx
+++ b/src/components/music/MusicPlatformBubbles.tsx
@@ -28,7 +28,7 @@ export function MusicPlatformBubbles({ entry }: { entry: MusicEntry }) {
 
 	return (
 		<div
-			className='flex flex-wrap gap-2 mt-3 items-start content-start'
+			className='mt-3 flex w-full flex-wrap items-center justify-center content-center gap-2'
 			onClick={stopBubble}
 			onKeyDown={e => e.stopPropagation()}
 			role='group'

--- a/src/components/music/MusicReleaseCard.tsx
+++ b/src/components/music/MusicReleaseCard.tsx
@@ -64,7 +64,8 @@ export function MusicReleaseCard({ entry }: MusicReleaseCardProps) {
 				},
 				body: { className: 'p-0' },
 				title: {
-					className: 'text-lg font-semibold line-clamp-2 px-3 pt-1 m-0',
+					className:
+						'm-0 px-3 pt-1 text-center text-lg font-semibold line-clamp-2',
 				},
 				content: {
 					className: 'px-3 pb-3 pt-2',


### PR DESCRIPTION
## Summary
- center release titles inside MusicReleaseCard
- center platform bubble row (Spotify/Apple/SoundCloud/YouTube) within each card
- applies to both Songs and Live sets / mixes sections

## Test plan
- npm run build
- mobile browser check on /music (390x844)
- verify title + link row centering in Songs and Live sets/mixes

Made with [Cursor](https://cursor.com)